### PR TITLE
Fix -Warray-bounds warnings

### DIFF
--- a/reg.c
+++ b/reg.c
@@ -18,8 +18,8 @@ static void reg_putraw(int c, char *s, int ln)
 	char *buf = malloc(strlen(pre) + strlen(s) + 1);
 	strcpy(buf, pre);
 	strcat(buf, s);
-	free(bufs[tolower(c)]);
-	bufs[tolower(c)] = buf;
+	free(bufs[(unsigned char) tolower(c)]);
+	bufs[(unsigned char) tolower(c)] = buf;
 	lnmode[tolower(c)] = ln;
 }
 


### PR DESCRIPTION
I have GCC 12 on my system, and compiling neatvi triggered these warnings

```
cc -c -Wall -O2 reg.c
reg.c: In function ‘reg_putraw’:
reg.c:21:18: warning: array subscript [-128, 255] is outside array bounds of ‘char *[256]’ [-Warray-bounds]
   21 |         free(bufs[tolower(c)]);
      |              ~~~~^~~~~~~~~~~~
reg.c:6:14: note: while referencing ‘bufs’
    6 | static char *bufs[256];
      |              ^~~~
reg.c:22:13: warning: array subscript [-128, 255] is outside array bounds of ‘char *[256]’ [-Warray-bounds]
   22 |         bufs[tolower(c)] = buf;
      |         ~~~~^~~~~~~~~~~~
reg.c:6:14: note: while referencing ‘bufs’
    6 | static char *bufs[256];
      |              ^~~~
```

The issue is that `tolower` does not necessarily return a value between 0 and 255, though this is to my understanding the implicit understanding in the code?