### PR TITLE
Reject unknown options, and fix array subscript outside bounds warning

### DIFF
--- a/reg.c
+++ b/reg.c
@@ -41,7 +41,7 @@ char *reg_get(int c, int *lnmode)
 	return reg_getraw(c, lnmode);
 }
 
-static void reg_putraw(int c, char *s, int ln)
+static void reg_putraw(unsigned char c, char *s, int ln)
 {
 	char *pre = isupper(c) && bufs[tolower(c)] ? bufs[tolower(c)] : "";
 	char *buf = malloc(strlen(pre) + strlen(s) + 1);

--- a/vi.c
+++ b/vi.c
@@ -2110,20 +2110,27 @@ int main(int argc, char *argv[])
 	char *prog = strchr(argv[0], '/') ? strrchr(argv[0], '/') + 1 : argv[0];
 	xvis = strcmp("ex", prog) && strcmp("neatex", prog);
 	for (i = 1; i < argc && argv[i][0] == '-'; i++) {
-		if (argv[i][1] == 's')
-			xled = 0;
-		if (argv[i][1] == 'e')
-			xvis = 0;
-		if (argv[i][1] == 'v')
-			xvis = 1;
-		if (argv[i][1] == 'h') {
-			printf("usage: %s [options] [file...]\n\n", argv[0]);
-			printf("options:\n");
-			printf("  -v    start in vi mode\n");
-			printf("  -e    start in ex mode\n");
-			printf("  -s    silent mode (for ex mode only)\n");
-			return 0;
-		}
+		if (argv[i][1] && argv[i][2] == '\0')
+			switch (argv[i][1]) {
+			case 's':
+				xled = 0;
+				continue;
+			case 'e':
+				xvis = 0;
+				continue;
+			case 'v':
+				xvis = 1;
+				continue;
+			case 'h':
+				printf("usage: %s [options] [file...]\n\n", argv[0]);
+				printf("options:\n");
+				printf("  -v    start in vi mode\n");
+				printf("  -e    start in ex mode\n");
+				printf("  -s    silent mode (for ex mode only)\n");
+				return 0;
+			}
+		fprintf(stderr, "%s: error: unknown option: %s\n", argv[0], argv[i]);
+		return 1;
 	}
 	dir_init();
 	syn_init();


### PR DESCRIPTION
Completion scripts for shells (such as Zsh) probe `vi --version`, which freeze indefinitely, unless Neatvi rejects options that are unknown. This [piece of Zsh completion code](https://sourceforge.net/p/zsh/code/ci/master/tree/Completion/Unix/Command/_vi) attempts to determine what variant of Vi it is:

```
        if _pick_variant vim='(N|)VIM' vi --version; then
            _vim
            return
        fi
```