### PR TITLE
vi: fix UTF-8 length in vi_char by replacing uc_len() with uc_len_expect()

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -21,6 +21,20 @@ int uc_len(char *s)
 	return 1;
 }
 
+/* return the expected length of a utf-8 character */
+int uc_len_expect(char c)
+{
+	if (~c & 0xc0)			/* ASCII or invalid */
+		return c > 0;
+	if (~c & 0x20)
+		return 2;
+	if (~c & 0x10)
+		return 3;
+	if (~c & 0x08)
+		return 4;
+	return 1;
+}
+
 /* the unicode codepoint of the given utf-8 character */
 int uc_code(char *s)
 {

--- a/vi.c
+++ b/vi.c
@@ -527,7 +527,7 @@ static char *vi_char(int (*next)(void), int kmap)
 		return NULL;
 	if ((c & 0xc0) == 0xc0) {
 		buf[0] = c;
-		n = uc_len(buf);
+		n = uc_len_expect(c);
 		for (i = 1; i < n; i++)
 			buf[i] = next();
 		buf[n] = '\0';

--- a/vi.h
+++ b/vi.h
@@ -98,6 +98,7 @@ void reg_done(void);
 
 /* utf-8 helper functions */
 int uc_len(char *s);
+int uc_len_expect(char c);
 int uc_wid(char *s);
 int uc_slen(char *s);
 int uc_code(char *s);


### PR DESCRIPTION
`uc_len()` cannot be used because it will inspect more characters than `b[0]`, and they have not yet been written into `buf`.

This is the corrected behaviour:

```shell
$ rm -f a && echo -e 'i\xc3\xa5\e:w\n:q' | ./vi -v a >/dev/null && cat a
å
```

Fixes: 3798edda8779 ("regex: handle invalid UTF-8 characters")