### PR TITLE
vi: fix refusal to save buffers with single insert/change modification

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -951,6 +951,7 @@ static int vi_change(int r1, int o1, int r2, int o2, int lnmode)
 	vi_drawfix(r1, r2 - r1 + 1, 1);
 	vi_insoff = xoff;
 	vi_insert = 1;
+	lbuf_tx(xb);
 	led_reset(&vi_ledins);
 	return VC_OK;
 }
@@ -1121,6 +1122,7 @@ static int vc_insert(int cmd)
 		vi_drawrow(0);
 	vi_insoff = xoff;
 	vi_insert = 1;
+	lbuf_tx(xb);
 	led_reset(&vi_ledins);
 	return VC_OK;
 }


### PR DESCRIPTION
Starting new change sets on `vi_insert = 1` assignments is a provisional fix, because undo history will not be optimal. However, refusing to save modified buffers is a fatal problem for the editor.

A single edit, with insert (or change) only, did not save the buffer:

```shell
$ rm -f a && echo -e 'iabcd\eZZ' | ./vi -v a >/dev/null && cat a
cat: a: No such file or directory
```

However, editing twice, with insert followed by append, works as expected:

```shell
$ rm -f a && echo -e 'iab\eacd\eZZ' | ./vi -v a >/dev/null && cat a
abcd
```

Fixes: ca69c12c1c44 ("vi: handle insert mode commands in vi.c")