### PR TITLE
Fix memory management for buffer assignment

### DIFF
--- a/reg.c
+++ b/reg.c
@@ -47,8 +47,8 @@ static void reg_putraw(int c, char *s, int ln)
 	char *buf = malloc(strlen(pre) + strlen(s) + 1);
 	strcpy(buf, pre);
 	strcat(buf, s);
-	free(bufs[tolower(c)]);
-	bufs[tolower(c)] = buf;
+	free(bufs[(unsigned char) tolower(c)]);
+	bufs[(unsigned char) tolower(c)] = buf;
 	lnmode[tolower(c)] = ln;
 }
 


### PR DESCRIPTION
```
cc -c -Wall -O2 -Wno-format-truncation reg.c
reg.c: In function 'reg_putraw':
reg.c:50:18: warning: array subscript [-128, 255] is outside array bounds of 'char *[256]' [-Warray-bounds=]
   50 |         free(bufs[tolower(c)]);
      |              ~~~~^~~~~~~~~~~~
reg.c:7:14: note: while referencing 'bufs'
    7 | static char *bufs[256];
      |              ^~~~
reg.c:51:13: warning: array subscript [-128, 255] is outside array bounds of 'char *[256]' [-Warray-bounds=]
   51 |         bufs[tolower(c)] = buf;
      |         ~~~~^~~~~~~~~~~~
reg.c:7:14: note: while referencing 'bufs'
    7 | static char *bufs[256];
      |              ^~~~